### PR TITLE
ci(circleci): define initial CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText:  Copyright © 2022 The Fern Authors <team@fernproxy.io>
+# SPDX-License-Identifier: Apache-2.0
+
+
+#TODO(ppiotr3k): add commit linting to enforce project guidelines
+#TODO(ppiotr3k): ? add PR linting to enforce project guidelines
+#TODO(ppiotr3k): add job (step?) to push container to Docker Hub
+#TODO(ppiotr3k): export test results in JUnit format for enhanced integration
+# -> https://circleci.com/docs/collect-test-data#overview
+# -> ? https://github.com/johnterickson/cargo2junit
+#TODO(ppiotr3k): add code coverage generation and export
+# -> https://circleci.com/docs/code-coverage
+#TODO(ppiotr3k): skip Rust tasks for changes in irrelevant files
+
+
+# Use version 2.1 of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.1/configuration-reference
+version: 2.1
+
+# Pipeline-wide parameters, always in scope, for all jobs, workflows, etc.
+# See: https://circleci.com/docs/pipeline-variables#pipeline-value-scope
+parameters:
+  # A `cache-version` parameter is used should cache need manual invalidation.
+  # While different kinds of caches are used in each job, a single parameter
+  # is used for simplicity, also allowing to invalidate all caches at once.
+  # Note: use the same `cache-version` value for all tasks in this pipeline.
+  cache-version:
+    description: Cache prefix version, used for cache invalidation
+    type: integer
+    default: 0
+
+# Define jobs to be invoked later in workflows.
+# See: https://circleci.com/docs/2.1/configuration-reference/#jobs
+jobs:
+  pre-checks:
+    # Specs: https://circleci.com/product/features/resource-classes/
+    resource_class: large
+    docker:
+      # Versions: https://circleci.com/developer/images/image/cimg/rust
+      - image: cimg/rust:1.63.0
+    working_directory: ~/fern-proxy/
+
+    steps:
+      # Checkout source.
+      # Multiple caches are used to increase the chance of a cache hit.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          keys:
+            - git-v<< pipeline.parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}
+            - git-v<< pipeline.parameters.cache-version >>-{{ .Branch }}-
+            - git-v<< pipeline.parameters.cache-version >>-
+      - checkout
+      # Should it be the first time the job is running on this revision.
+      - save_cache:
+          key: git-v<< pipeline.parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/fern-proxy/.git
+
+      # Restore artifact cache.
+      # Multiple caches are used to increase the chance of a cache hit.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          keys:
+            - cargo-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-v<< pipeline.parameters.cache-version >>-{{ arch }}-
+            - cargo-v<< pipeline.parameters.cache-version >>-
+      - restore_cache:
+          keys:
+            - target-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - target-v<< pipeline.parameters.cache-version >>-{{ arch }}-
+            - target-v<< pipeline.parameters.cache-version >>-
+
+      # Run pre-checks.
+      # This is where the actual content of this CI job happens.
+      - run:
+          name: Run `cargo check` [unoptimized + debuginfo]
+          command: cargo check --all-targets --profile=test
+      - run:
+          name: Run `cargo test` [unoptimized + debuginfo]
+          command: cargo test --tests --no-fail-fast
+      - run:
+          name: Run `cargo clippy` [unoptimized + debuginfo]
+          command: cargo clippy -- -W clippy::cognitive_complexity
+      - run:
+          name: Run `cargo fmt` [unoptimized + debuginfo]
+          command: cargo fmt -- --check
+
+      # Save artifact cache.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - save_cache:
+          key: cargo-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/registry
+            - ~/.cargo/git
+      # Do not cache artifacts built at this stage in case build does fail.
+      # See: https://circleci.com/docs/caching#writing-to-the-cache-in-workflows
+      # Artifacts can however be passed along for optimization through workspace.
+      # See: https://circleci.com/docs/workspaces
+      - persist_to_workspace:
+          root: .
+          paths:
+            - target
+
+
+  build-native:
+    # Specs: https://circleci.com/product/features/resource-classes/
+    resource_class: small
+    docker:
+      # Versions: https://circleci.com/developer/images/image/cimg/rust
+      - image: cimg/rust:1.63.0
+    working_directory: ~/fern-proxy/
+
+    steps:
+      # Checkout source.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          # A 'build-native' should always happen after a 'pre-checks',
+          # therefore required cache should have been created previously.
+          keys:
+            - git-v<< pipeline.parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}
+      - checkout
+
+      # Restore artifact cache.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          # A 'build-native' should always happen after a 'pre-checks',
+          # therefore required cache should have been created previously.
+          keys:
+            - cargo-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - attach_workspace:
+          at: ~/fern-proxy/
+
+      # Build native.
+      # This is where the actual content of this CI job happens.
+      - run:
+          name: Run `cargo build` [unoptimized + debuginfo]
+          command: cargo build
+
+      # Save artifact cache.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - save_cache:
+          # At this point artifacts built can be considered safe to cache.
+          key: target-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/fern-proxy/target
+
+
+  build-container:
+    # Specs: https://circleci.com/product/features/resource-classes/
+    resource_class: large
+    machine:
+      # Versions: https://circleci.com/developer/images?imageType=machine
+      image: ubuntu-2204:2022.07.1
+      # DLC volumes are deleted after 3 days of not being used in a job.
+      # See: https://circleci.com/docs/docker-layer-caching#how-dlc-works
+      #TODO(ppiotr3k): evaluate 'DLC' vs 'docker build --cache-from'
+      docker_layer_caching: true
+    working_directory: ~/fern-proxy/
+
+    steps:
+      # Checkout source.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          # A 'build-container' should always happen after a 'pre-checks',
+          # therefore required cache should have been created previously.
+          keys:
+            - git-v<< pipeline.parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}
+      - checkout
+
+      # Restore artifact cache.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          # A 'build-container' should always happen after a 'pre-checks',
+          # therefore required cache should have been created previously.
+          keys:
+            - cargo-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - restore_cache:
+          # A 'build-container' should always happen after a 'build-native',
+          # therefore required cache should have been created previously.
+          keys:
+            - target-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+
+      # Build container.
+      # This is where the actual content of this CI job happens.
+      - run:
+          name: Run `make build` [optimized]
+          command: make buid
+
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.1/configuration-reference/#workflows
+workflows:
+  # Pinning the version enables warnings for deprecation or breaking changes
+  version: 2
+
+  # Workflow triggered for each 'push' or 'pull_request' event.
+  # Note: builds for pull requests from forked repositories are blocked in CircleCI config.
+  ci-build:
+    jobs:
+      # Pre-checks are mandatory whatever is the branch.
+      - pre-checks
+
+      # To speed up developer feedback loop, and support the 'fail-fast' approach,
+      # a fast 'native' build is always performed in following cases:
+      # - code commits to all branches, except `dev` and `main`
+      # - pull requests to all branches, except `dev` and `main`
+      - build-native:
+          filters:
+            branches:
+              ignore:
+                - dev
+                - main
+          requires:
+            - pre-checks
+
+      # To ensure deployability when moving forward in the code delivery pipeline,
+      # a longer 'container' build is only performed in following cases:
+      # - pull requests to `dev` or `main` branches (regular git-flow)
+      # - code commits to `dev` or `main` branches (shouldn't happen per git-flow)
+      - build-container:
+          filters:
+            branches:
+              only:
+                - dev
+                - main
+          requires:
+            - pre-checks


### PR DESCRIPTION
Use 'medium' resource class for `pre-checks` as this is where most heavy compilation work happens, yet the gain from using 'large' is not enough at this state of the project.

CPU usage saturation during `pre-checks` (fresh cache) with:
- 'large' : 15sec/1min45 (14%),
- 'medium': 60sec/2min30 (40%). ('small' would has better saturation but total time would exceed 5min)

Use 'small' resource class for `build-native` as with 'medium' CPU usage barely reach 50%, and with 'small' 100% is achieved but during only a very short amount of time (<15sec).

Fixes: #1