### PR TITLE
ci(circleci): add code coverage measurement to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,17 @@
 #TODO(ppiotr3k): export test results in JUnit format for enhanced integration
 # -> https://circleci.com/docs/collect-test-data#overview
 # -> ? https://github.com/johnterickson/cargo2junit
-#TODO(ppiotr3k): add code coverage generation and export
-# -> https://circleci.com/docs/code-coverage
 #TODO(ppiotr3k): skip Rust tasks for changes in irrelevant files
 
 
 # Use version 2.1 of CircleCI pipeline process engine.
 # See: https://circleci.com/docs/2.1/configuration-reference
 version: 2.1
+
+# Orbs required by this pipeline for integrations with third-party tools.
+# See: https://circleci.com/docs/orb-intro
+orbs:
+  codecov: codecov/codecov@3.2.3
 
 # Pipeline-wide parameters, always in scope, for all jobs, workflows, etc.
 # See: https://circleci.com/docs/pipeline-variables#pipeline-value-scope
@@ -195,7 +198,55 @@ jobs:
           command: make build
 
 
-# Invoke jobs via workflows
+  measure-code-coverage:
+    # Specs: https://circleci.com/product/features/resource-classes/
+    resource_class: large
+    machine:
+      # Versions: https://circleci.com/developer/images?imageType=machine
+      image: ubuntu-2204:2022.07.1
+      # DLC volumes are deleted after 3 days of not being used in a job.
+      # See: https://circleci.com/docs/docker-layer-caching#how-dlc-works
+      #TODO(ppiotr3k): evaluate 'DLC' vs 'docker build --cache-from'
+      docker_layer_caching: true
+    working_directory: ~/fern-proxy/
+
+    steps:
+      # Checkout source.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          # A 'measure-code-coverage' should always happen after a 'pre-checks',
+          # therefore required cache should have been created previously.
+          keys:
+            - git-v<< pipeline.parameters.cache-version >>-{{ .Branch }}-{{ .Revision }}
+      - checkout
+
+      # Restore artifact cache.
+      # A version prefix is used should cache need manual invalidation.
+      # See: https://circleci.com/docs/caching#clearing-cache
+      - restore_cache:
+          # A 'measure-code-coverage' should always happen after a 'pre-checks',
+          # therefore required cache should have been created previously.
+          keys:
+            - cargo-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - restore_cache:
+          # A 'measure-code-coverage' should always happen after a 'build-native',
+          # therefore required cache should have been created previously.
+          keys:
+            - target-v<< pipeline.parameters.cache-version >>-{{ arch }}-{{ checksum "Cargo.lock" }}
+
+      # Measure code coverage, store HTML report as artifact, upload LCOV report to Codecov.
+      # This is where the actual content of this CI job happens.
+      - run:
+          name: Run `make coverage` [unoptimized + debuginfo + instrument-coverage]
+          command: make coverage
+      - store_artifacts:
+          path: .coverage/html
+      - codecov/upload:
+          file: .coverage/lcov
+
+
+# Invoke jobs via workflows.
 # See: https://circleci.com/docs/2.1/configuration-reference/#workflows
 workflows:
   # Pinning the version enables warnings for deprecation or breaking changes
@@ -226,6 +277,20 @@ workflows:
       # - pull requests to `dev` or `main` branches (regular git-flow)
       # - code commits to `dev` or `main` branches (shouldn't happen per git-flow)
       - build-container:
+          filters:
+            branches:
+              only:
+                - dev
+                - main
+          requires:
+            - pre-checks
+
+      # To monitor risk of introducing code with undetected software defects
+      # when moving forward in the code delivery pipeline,
+      # a longer code coverage measurement is only performed in following cases:
+      # - pull requests to `dev` or `main` branches (regular git-flow)
+      # - code commits to `dev` or `main` branches (shouldn't happen per git-flow)
+      - measure-code-coverage:
           filters:
             branches:
               only:

--- a/.coverage/.gitkeep
+++ b/.coverage/.gitkeep
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText:  Copyright © 2022 The Fern Authors <team@fernproxy.io>
+# SPDX-License-Identifier: Apache-2.0
+
+There is nothing in this file, except this info message to explain we want
+to keep it. The sole purpose of this `.gitkeep` is to ensure a `.coverage`
+directory always exists, as it simplifies writing the `make coverage` target.

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 .circleci
+.coverage
 .env
 .git
 .github
@@ -10,6 +11,7 @@ doc
 examples
 target
 *.md
+*.profraw
 *.yml
 Dockerfile
 LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 # SPDX-FileCopyrightText:  Copyright © 2022 The Fern Authors <team@fernproxy.io>
 # SPDX-License-Identifier: Apache-2.0
 
+# Ensure a `.coverage` directory always exists
+!/.coverage
+/.coverage/*
+!/.coverage/.gitkeep
+
+# Build artifacts are happier outside of source control
 /target

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ CMD [ "./fern-proxy" ]
 
 FROM rust:1.63-slim AS dev-env
 
-# Required by `openssl-sys` crate, a dependency for `grcov`
+# Required by `openssl-sys` crate, a dependency for `grcov` (code coverage)
 RUN apt-get update \
         && apt-get install -y --no-install-recommends cmake libssl-dev pkg-config \
         && rm -rf /var/lib/apt/lists/*
@@ -29,8 +29,9 @@ RUN rustup component add rustfmt
 # Required for linting (style, complexity, ...)
 RUN rustup component add clippy
 
-# Required for code coverage
+# Required for code coverage measurement
 RUN cargo install grcov
+RUN rustup component add llvm-tools-preview
 
 # Required for REPL
 RUN cargo install cargo-watch


### PR DESCRIPTION
Add code coverage measurement with results (HTML, LCOV):
- available locally to developer
- stored as build artifact by CI (only HTML report)
- published to [codecov.io](https://about.codecov.io/) by CI (only LCOV report)

Note: due to #3, changes introduced in this PR won't be taken into account until they reach `dev` or `main` branches. :shrug: 

### :muscle: My Motivation:
Writing tests is essential to develop quality software. However, without code coverage the degree to which source code is executed by the test suite can't be really known. Adding code coverage enables to monitor the risk of introducing code with undetected software defects, and to enhance the test suite for code already in the codebase.

### :brain: My Solution:

- `make coverage` use code instrumentation stabilized in rustc 1.61 to perform source-based coverage even accurate at branch level.

- Code instrumentation requires additional compilation flags which are set leveraging current `dev` container.
Profiling is performed by executing the test suite on resulting instrumented build artifacts.

- `grcov` process resulting profiling files to produce reports in HTML and LCOV formats in `.coverage` directory at project's root.

This design allows producing those coverage reports without "polluting" the env with profiling artifacts, while making them available to developer and CI jobs for further processing.

Coverage measurements with defined settings seems to produce rather accurate results.
Some `derive` macros and other logging statements needs to be further investigated for potentially additional tweaking.