### PR TITLE
ci(makefile): use BuildKit plain output when `CI` env var is defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PROJECT := fern-proxy
 
 COMPOSE = docker-compose -p $(PROJECT)
-DOCKER  = DOCKER_BUILDKIT=1 docker
+DOCKER  = DOCKER_BUILDKIT=1 $(if $(CI),BUILDKIT_PROGRESS=plain) docker
 
 
 SHELL = /bin/sh


### PR DESCRIPTION
Force BuildKit to output in a text log friendly format when running in CI.

Note: due to #3, changes introduced in this PR won't be taken into account until they reach `dev` or `main` branches. :shrug:

### :muscle: My Motivation:

BuildKit _should_ automatically adapt progress output format based on environment.
Unfortunately something doesn't play well with CircleCI and the produced output - while great for TTY - is terrible for text logs, leading to thousands of garbage lines in CircleCI's job logs. We want CI job logs to be usable, not filled with garbage.

### :brain: My Solution:

Based on [Docker CLI doc](https://github.com/docker/cli/blob/f3ed630f8feaaa02bc129150a7c7e1ca6a782a95/docs/reference/commandline/cli.md#environment-variables) and [CircleCI built-in env variables doc](https://circleci.com/docs/built-in-environment-variables), use `BUILDKIT_PROGRESS=plain` env variable when `CI` variable is set in the environment to force BuildKit output in a text log friendly format.
`CI` seems to be an env variable commonly set by other CI providers (ex: GitLab, GitHub, Travis) for portability.


